### PR TITLE
Fix the CRC32 of README.MD.

### DIFF
--- a/bl_reimu/files.js
+++ b/bl_reimu/files.js
@@ -1,5 +1,5 @@
 {
-	"README.MD": 1709333351,
+	"README.MD": 1766080661,
 	"patch.js": 1673208829,
 	"th10/face/pl00/face_pl00an_u.png": 1469980073,
 	"th10/face/pl00/face_pl00dp_u.png": 2050956969,


### PR DESCRIPTION
Accidentally clicked on this patch in the new GUI, and noticed that it didn't actually download. Here's the fix for that.